### PR TITLE
changing git svn rebase to fetch

### DIFF
--- a/git_mirror.sh
+++ b/git_mirror.sh
@@ -75,7 +75,7 @@ function git_mirror() {
 	hg) c="hg clone $from ."
 		p='hg pull';;
 	svn) c="svn clone $arg $from ."
-		p="svn rebase";;
+		p="svn fetch";;
 	*) echo "$type is unsupported"; return 1;;
 	esac
 


### PR DESCRIPTION
bc
- update the master history https://www.google.com/search?q=git+svn
  
  > Once tracking a Subversion repository (with any of the above methods), the git repository can be updated from Subversion by the fetch command
- is faster?
- rebase is rarely useful bc the remote rarely change its history

reverted bc
- git svn rebase" is the right command. git svn fetch isn't a lightweight "git svn pull". it doesn't update the master branch https://www.google.com/search?q=git+svn+pull

> git svn fetch only copies new revisions to your local object database, very much like git fetch – both only synchronize object databases. It will not update your branch and working copy.
