### PR TITLE
add --dry-run etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,66 @@
-# mirror
 
 This repo is a meta-repository for housing all issues and tooling related to the administration
 of the mirror org and its repositories.
 
-## Index
+# usage
+
+to mirror a svn source forge repo to abc/123
+
+~~~
+export org=abc
+export REPO_HOME=~/repos
+mkdir -p $REPO_HOME
+bash git_mirror.sh 123 svn https://svn.code.sf.net/p/123/code/trunk --dry-run
+~~~
+
+to update all small bzr mirrors hosted here 
+
+~~~
+bash mirror.sh --type=bzr --interactive --small --dry-run
+~~~
+
+
+# unable to pull --  history lost upstream
+
+we are working on a patch that will resume svn cvs mirrors
+
+https://github.com/mirror/mirror/discussions
+
+until then sometimes svn cvs mirrors rewrite the history from scratch. when this happens
+
+store all your changes
+
+~~~
+git format-patch -3
+git stash
+git checkout -b oldmaster
+~~~
+
+delete and download again
+
+~~~
+git checkout HEAD~99
+git branch -d master
+git fetch
+git checkout origin master
+~~~
+
+# Index
 
 | Repo Name | Mirror URL | Upstream URL |
 |-----------|------------|--------------|
 | TODO      | TODO       | TODO         |
 
-## About
+# About
 
 Mirror is dedicated to hosting unofficial Git mirrors of various popular opens-source
-repositories that are scattered across the internet. 
+repositories that are scattered across the internet. It arose from my need to host and publish my patches. 
 
-## Contributing
+# Contributing
 
 There are various ways one can contribute. 
 
-### Requesting a new repository mirror
+## Requesting a new repository mirror
 
 Before you request that a repository be mirrored, please take a look through our repositories to 
 make sure that the repository you are looking for isn't already mirrored. 
@@ -28,7 +70,7 @@ provide us with some details about the repository you'd like to see mirrored. Ge
 can only mirror repositories that have licenses that allow for redistribution of the source
 code. 
 
-### Requesting an existing mirror be removed
+## Requesting an existing mirror be removed
 
 There are only two cases when a mirror will be considered for removal:
 
@@ -44,7 +86,7 @@ an issue in this repo and provide us with some more details about the circumstan
 However, if there are no technical or legal grounds for the removal of the mirror, the issue 
 will be closed without any further action taken. 
 
-### Making contributions yourself
+## Making contributions yourself
 
 If you'd rather contribute directly to the project, please feel free to create a pull request. It is 
 also highly recommended that you read the [CONTRIBUTING][CONTRIBUTING.md] docs for more detailed

--- a/git_mirror.sh
+++ b/git_mirror.sh
@@ -6,6 +6,7 @@ function show_usage() {
 	echo mirror repo to git hub
 	echo 'example usage: git_mirror.sh abc bzr http://launchpad/abc "" --debug --dry-run
 --fast skip svn cvs
+--interactive require user input
 --resume experiment to resume existing svn cvs mirror'
 	exit 0
 }
@@ -24,6 +25,7 @@ issvn=false
 isdebug=false
 isdry=false
 isfast=false
+isint=false
 isresume=false
 istest=false
 
@@ -37,12 +39,78 @@ case "$arg" in
 		isdry=true;;
 	-f|--fast)
 		isfast=true;;
+	-i|--interactive)
+		isint=true;;
 	-r|--resume)
 		isresume=true;;
 	-t|--test)
 		istest=true;;
 esac
 done
+
+# disable all commands
+if $isdry; then
+	shopt -s expand_aliases
+	for a in bzr git hg mkdir popd pushd rm svn; do
+		alias $a="echo $a"
+	done
+	# type git; git -v
+fi
+
+function format() {
+	if $1; then
+		bold=$(tput bold)
+	fi
+	if [ $2 -gt -1 ]; then
+		color=$(tput setaf $2)
+	fi
+	normal=$(tput sgr0)
+	shift 2
+	echo "${bold}${color}$@${normal}"
+}
+
+function is_big() {
+	echo checking size
+	json=$(curl -s https://api.github.com/repos/$org/$to)
+	size=$(echo $json|jshon -e size -u)
+if [ $size -gt 100000 ]; then
+	format false 9 $(numfmt --to=iec $(($size*1024))) too big for --fast
+	exit 1
+fi
+}
+
+# are we behind ?
+function is_behind() {
+	echo comparing head dates
+
+	case "$type" in
+	git)
+		local c="clone --quiet --depth=1";;
+	hg)
+		local c=" hg clone";;
+	*) format false 9 add $type date comparison
+		return 0;;
+	esac
+
+	# shopt -u expand_aliases
+	rm -rf tmp
+	mkdir tmp
+	pushd tmp
+	git $c $from .
+	sd=$(TZ=UTC0 git show HEAD --quiet --date=iso-strict-local --format="%cd"|sed "s,+00:00,Z,")
+	popd
+	# shopt -s expand_aliases
+	
+	json=$(curl -s https://api.github.com/repos/$org/$to/branches/master)
+	md=$(echo $json|jq -r '.. | .date? | strings'|tail -1)
+
+	if [ "$sd" == "$md" ]; then
+		echo $to up to date
+		exit 0
+	else
+		echo head dates differ $sd $md
+	fi
+}
 
 function mirror_exist() {
 	if $isdry; then
@@ -51,7 +119,6 @@ function mirror_exist() {
 	fi
 	echo check for existing repo
 	json=$(curl -s https://api.github.com/repos/$org/$to)
-	# echo $json
 	error=$(echo "$json" | jshon -Q -e message -u)
 	if [ -n "$error" ] && [[ "$error" != "API rate limit exceeded"* ]]; then
 		echo $error;
@@ -91,14 +158,21 @@ function create_repo() {
 	from=$3
 	arg=$4
 
+	# title
+	echo 
+	format true -1 $to
+
 	# repo home
-	if [ -z "$REPO_HOME" ]; then echo "REPO_HOME not set using ."; REPO_HOME=.; fi
+	if [ -z "$REPO_HOME" ]; then
+		# echo "REPO_HOME not set using ."
+		REPO_HOME=.
+	fi
 	if [ ! -d "$REPO_HOME" ]; then echo "$REPO_HOME doesn't exist"; return 1; fi
 	dir=$REPO_HOME/$to
 
 # target org
 if [ -z "$org" ]; then
-	echo org is unset using mirror
+	# echo org is unset using mirror
 	org=mirror
 fi
 
@@ -107,23 +181,12 @@ if $isdebug; then
 	set -x
 fi
 
-# disable all commands
-if $isdry; then
-	shopt -s expand_aliases
-	for a in bzr git hg mkdir popd pushd rm svn; do
-		alias $a="echo $a"
-	done
-	# type git; git -v
-fi
-
 # test
 if $istest; then
-	mirror_exist
+	is_behind
+	# mirror_exist
 	exit
 fi
-
-	# log
-	echo pushing $to $(date -Is)
 	
 	# type
 	m="push --mirror"
@@ -156,17 +219,17 @@ fi
 		m="push origin HEAD:$branch"
 	fi
 
-
 # clone
 # why do we need this?
 # isrepo=($isgit && -f $dir/HEAD || !$isgit && -f $dir/.git/HEAD)
 if [[ -d $dir ]]; then
 	echo resume existing repo
 	pushd $dir
+	git $p
 
 else
 	if $isfast && ($issvn || $iscvs); then
-		echo --fast disable $type
+		echo --fast disable new clones for $type
 		exit 1
 	fi
 
@@ -174,6 +237,10 @@ else
 		echo $type not support resume
 		exit 1
 	fi
+
+	is_big
+
+	is_behind
 
 	echo creating new folder $to
 	mkdir -p $dir
@@ -203,22 +270,26 @@ else
 	fi
 fi
 
-	# select branch
+	# select branch - fix this
 	if $isbzr; then
 		git checkout bzr/master
 	fi
 
 	# sync
-	git $p
 	git $m
 res=$?
 
 	# return to home
 	popd
 
+# keep big and slow repos 
 if [ $isfast -a $res -eq 0 ]; then
-	echo fast success $to
+	format false 10 fast success $to
 	rm -rf $dir
+fi
+
+if $isint; then
+	read -p "press return to continue"
 fi
 
 if $isdebug; then set +x; fi

--- a/git_mirror.sh
+++ b/git_mirror.sh
@@ -4,7 +4,9 @@
 
 function show_usage() {
 	echo mirror repo to git hub
-	echo example usage: "git_mirror.sh abc bzr http://launchpad/abc "" --debug --dry-run"
+	echo 'example usage: git_mirror.sh abc bzr http://launchpad/abc "" --debug --dry-run
+--fast skip svn cvs
+--resume experiment to resume existing svn cvs mirror'
 	exit 0
 }
 
@@ -15,27 +17,62 @@ if [ $# -lt 3 ]; then
 fi
 
 # defaults
-isdry=false
+isbzr=false
+iscvs=false
+isgit=false
+issvn=false
 isdebug=false
+isdry=false
+isfast=false
+isresume=false
+istest=false
 
-# while [ $# -ge 1 ]; do
-for var in "$@"; do
-case "$var" in
+for arg in "$@"; do
+case "$arg" in
 	-\?|-h|--help|--usage)
 		show_usage;;
-	-n|--dry-run)
-		isdry=true;;
 	-d|--debug)
 		isdebug=true;;
+	-n|--dry-run)
+		isdry=true;;
+	-f|--fast)
+		isfast=true;;
+	-r|--resume)
+		isresume=true;;
+	-t|--test)
+		istest=true;;
 esac
 done
 
-function create_repo() {
-	name=$1
-	description=$2
+function mirror_exist() {
+	if $isdry; then
+		echo mirror_exist 0
+		return 0
+	fi
+	echo check for existing repo
+	json=$(curl -s https://api.github.com/repos/$org/$to)
+	# echo $json
+	error=$(echo "$json" | jshon -Q -e message -u)
+	if [ -n "$error" ] && [[ "$error" != "API rate limit exceeded"* ]]; then
+		echo $error;
+		return 1
+	else
+		echo $org/$to exist
+		return 0
+	fi
+}
 
+# create empty repo
+function create_repo() {
+	description="$from $arg"
+
+	if [ -z "$user" ]; then
+		echo user unset
+		return 1
+	fi
+	
 	# create repo
-	json=$(curl -s -u "$user:$pwd" -d "{\"name\":\"$name\"}" https://api.github.com/orgs/$org/repos)
+	json=$(curl -s -u "$user:$pwd" -d "{\"name\":\"$to\"}" https://api.github.com/orgs/$org/repos)
 	error=$(echo "$json" | jshon -Q -e message -u)
 	if [ -n "$error" ]; then
 		echo $error;
@@ -46,8 +83,7 @@ function create_repo() {
 	json=$(curl -s -u "$user:$pwd" -X PATCH -d "{\"name\":\"$name\", \"description\":\"$description\"}" https://api.github.com/repos/$org/$name)
 }
 
-# function git_mirror() {
-	# vars
+	# args
 	TO=(${1//\// });
 	to=${TO[0]}
 	branch=${TO[1]}
@@ -66,87 +102,105 @@ if [ -z "$org" ]; then
 	org=mirror
 fi
 
-	# create boolean
-	isbzr=`if [[ "$type" =~ "bzr" ]]; then printf true; else printf false; fi`
-	isgit=`if [[ "$type" =~ "git" ]]; then printf true; else printf false; fi`
-	issvn=`if [[ "$type" =~ "svn" ]]; then printf true; else printf false; fi`
-
-
 # debug
 if $isdebug; then
-	echo to $to
-	echo branch $branch
-	echo type $type
-	echo from $from
-	echo arg $arg
 	set -x
 fi
 
 # disable all commands
 if $isdry; then
 	shopt -s expand_aliases
-	for a in bzr curl git hg jshon mkdir popd pushd svn; do
+	for a in bzr git hg mkdir popd pushd rm svn; do
 		alias $a="echo $a"
 	done
-	type git
-	git -v
+	# type git; git -v
 fi
 
-# create repo if git_login is sourced
-if [ -n "$user" ]; then
-	json=$(curl -s https://api.github.com/repos/$org/$to)
-	error=$(echo "$json" | jshon -Q -e message -u)
-	if [ -n "$error" ] && [[ "$error" != "API rate limit exceeded"* ]]; then
-		echo $error;
-		if ! create_repo $to "$from $arg"; then
-			return 1
-		fi
-	fi
+# test
+if $istest; then
+	mirror_exist
+	exit
 fi
-
-	# push command
-	if [ -n "$branch" ]; then
-		dir=${dir}_$branch
-		m="push origin HEAD:$branch"
-	else
-		if $isbzr; then
-			m="push --tags origin HEAD:master"
-		elif $issvn; then
-			m="push"
-		else
-			m="push --mirror"
-		fi
-	fi
 
 	# log
 	echo pushing $to $(date -Is)
-
-	# pull command
+	
+	# type
+	m="push --mirror"
+	r='add'
 	case "$type" in
-	bzr) c="bzr clone $from ."
-		p='bzr sync bzr/master';;
-	cvs) c="cvsimport -i -d $from $arg"
+	bzr) isbzr=true
+		c="bzr clone $from ."
+		p='bzr sync bzr/master'
+		m="push --tags origin HEAD:master";;
+	cvs) iscvs=true
+		c="cvsimport -i -d $from $arg"
 		p="$c";;
-	git) c="clone --mirror $from ."
-		p='remote update';;
+	git) isgit=true
+		c="clone --mirror $from ."
+		p='remote update'
+		s=set-url
+		r='set-url --push';;
 	hg) c="hg clone $from ."
 		p='hg pull';;
-	svn) c="svn clone $arg $from ."
-		p="svn rebase";;
+	svn) issvn=true
+		c="svn clone $arg $from ."
+		p="svn rebase"
+			m="push";;
 	*) echo "$type is unsupported"; return 1;;
 	esac
-
-	if $isgit; then
-		r='set-url --push'
-	else
-		r='add'
+	
+	# branch push command
+	if [ -n "$branch" ]; then
+		dir=${dir}_$branch
+		m="push origin HEAD:$branch"
 	fi
 
+
 # clone
-if [[ ! -d $dir || ! ($isgit && -f $dir/HEAD || !$isgit && -f $dir/.git/HEAD) ]]; then
-	mkdir -p $dir; pushd $dir
-	git $c
-	git remote $r origin git@github.com:$org/$to.git
+# why do we need this?
+# isrepo=($isgit && -f $dir/HEAD || !$isgit && -f $dir/.git/HEAD)
+if [[ -d $dir ]]; then
+	echo resume existing repo
+	pushd $dir
+
+else
+	if $isfast && ($issvn || $iscvs); then
+		echo --fast disable $type
+		exit 1
+	fi
+
+	if $isresume && ! $isgit; then
+		echo $type not support resume
+		exit 1
+	fi
+
+	echo creating new folder $to
+	mkdir -p $dir
+	pushd $dir
+
+	if ! mirror_exist; then
+		echo create new repo
+		if ! create_repo; then
+			exit 1
+		fi
+	fi
+
+	# this produce errors related to pull requests refs/pull/1/head
+	# if $isresume && $isgit; then
+	if false; then
+		echo clone existing mirror 
+		git clone --mirror git@github.com:$org/$to .
+		echo update remote
+		git remote $s origin $from
+		git remote $r origin git@github.com:$org/$to
+
+	else
+		echo clone from source
+		git $c
+		echo update remote
+		git remote $r origin git@github.com:$org/$to
+	fi
 fi
 
 	# select branch
@@ -154,15 +208,17 @@ fi
 		git checkout bzr/master
 	fi
 
-	# change directory
-	pushd $dir
-
 	# sync
 	git $p
 	git $m
+res=$?
 
 	# return to home
 	popd
 
-	if $isdebug; then set +x; fi
-# }
+if [ $isfast -a $res -eq 0 ]; then
+	echo fast success $to
+	rm -rf $dir
+fi
+
+if $isdebug; then set +x; fi

--- a/git_mirror.sh
+++ b/git_mirror.sh
@@ -100,7 +100,7 @@ function have_api() {
 }
 
 function is_big() {
-	if ! $haveapi; then	return 0; fi
+	if ! $haveapi || $isdry; then	return 0; fi
 	echo checking size
 	json=$(curl -s $login https://api.github.com/repos/$org/$to)
 	size=$(echo $json|jshon -e size -u)
@@ -113,9 +113,9 @@ else
 fi
 }
 
-# are we behind ?
+# only git has shallow clones
 function is_behind() {
-	if ! $haveapi; then	return 0; fi
+	if ! $haveapi || $isdry || ! $isgit; then	return 0; fi
 	echo comparing head dates
 
 	case "$type" in
@@ -221,8 +221,12 @@ fi
 		p='remote update'
 		s=set-url
 		r='set-url --push';;
-	hg) c="hg clone $from ."
-		p='hg pull';;
+	hg) c="clone --mirror hg::$from ."
+		p="pull"
+		r='set-url --push';;
+		# git-hg is broken "Cannot chdir to $cdup..."
+		# c="hg clone $from ."
+		# p='hg pull';;
 	svn) issvn=true
 		c="svn clone $arg $from ."
 		p="svn rebase"

--- a/git_mirror.sh
+++ b/git_mirror.sh
@@ -2,6 +2,9 @@
 # Repository mirrorer
 # © John Peterson. License GNU GPL 3.
 
+# import
+source git_login.sh 2>/dev/null
+
 function show_usage() {
 	echo mirror repo to git hub
 	echo 'example usage: git_mirror.sh abc bzr http://launchpad/abc "" --debug --dry-run
@@ -59,28 +62,60 @@ fi
 
 function format() {
 	if $1; then
-		bold=$(tput bold)
+		local bold=$(tput bold)
 	fi
 	if [ $2 -gt -1 ]; then
-		color=$(tput setaf $2)
+		local color=$(tput setaf $2)
 	fi
 	normal=$(tput sgr0)
 	shift 2
 	echo "${bold}${color}$@${normal}"
 }
 
-function is_big() {
-	echo checking size
+# cloud machine are rate limited 
+function have_api() {
 	json=$(curl -s https://api.github.com/repos/$org/$to)
+	error=$(echo $json | jshon -Q -e message -u)
+	if [[ "$error" = "API rate limit exceeded"* ]]; then	
+	# if [[ -n "$error" ]]; then	
+	# if true; then	
+		# echo error $error;
+		if [ -z "$user" ]; then
+			echo user unset API unavailable
+		else
+			# retry with credentials 
+			json=$(curl -s -u "$user:$pwd" https://api.github.com/repos/$org/$to)
+			error=$(echo $json | jshon -Q -e message -u)
+			if [ -z "$error" ]; then
+				eval $1=true
+				login="-u $user:$pwd"
+			else
+				# echo error $error
+			echo API unavailable
+			fi
+		fi
+	else
+		eval $1=true
+	fi
+}
+
+function is_big() {
+	if ! $haveapi; then	return 0; fi
+	echo checking size
+	json=$(curl -s $login https://api.github.com/repos/$org/$to)
 	size=$(echo $json|jshon -e size -u)
+	megs=$(numfmt --to=iec $(($size*1024)))
 if [ $size -gt 100000 ]; then
-	format false 9 $(numfmt --to=iec $(($size*1024))) too big for --fast
+	format false 9 $megs too big for --fast
 	exit 1
+else
+	format false 2 $megs
 fi
 }
 
 # are we behind ?
 function is_behind() {
+	if ! $haveapi; then	return 0; fi
 	echo comparing head dates
 
 	case "$type" in
@@ -96,32 +131,30 @@ function is_behind() {
 	rm -rf tmp
 	mkdir tmp
 	pushd tmp
+	echo cloning $from ...
 	git $c $from .
 	sd=$(TZ=UTC0 git show HEAD --quiet --date=iso-strict-local --format="%cd"|sed "s,+00:00,Z,")
 	popd
 	# shopt -s expand_aliases
 	
-	json=$(curl -s https://api.github.com/repos/$org/$to/branches/master)
+	json=$(curl -s $login https://api.github.com/repos/$org/$to/branches/master)
 	md=$(echo $json|jq -r '.. | .date? | strings'|tail -1)
 
 	if [ "$sd" == "$md" ]; then
-		echo $to up to date
+		format false 2 up to date $sd
 		exit 0
 	else
-		echo head dates differ $sd $md
+		format false 9 updating from $md to $sd
 	fi
 }
 
 function mirror_exist() {
-	if $isdry; then
-		echo mirror_exist 0
-		return 0
-	fi
+	if ! $haveapi || $isdry; then	return 0; fi
 	echo check for existing repo
-	json=$(curl -s https://api.github.com/repos/$org/$to)
-	error=$(echo "$json" | jshon -Q -e message -u)
-	if [ -n "$error" ] && [[ "$error" != "API rate limit exceeded"* ]]; then
-		echo $error;
+	json=$(curl -s $login https://api.github.com/repos/$org/$to)
+	error=$(echo $json | jshon -Q -e message -u)
+	if [[ "$error" = "Not Found" ]]; then
+		format false 10 new mirror $org/$to;
 		return 1
 	else
 		echo $org/$to exist
@@ -139,7 +172,7 @@ function create_repo() {
 	fi
 	
 	# create repo
-	json=$(curl -s -u "$user:$pwd" -d "{\"name\":\"$to\"}" https://api.github.com/orgs/$org/repos)
+	json=$(curl -s $login -d "{\"name\":\"$to\"}" https://api.github.com/orgs/$org/repos)
 	error=$(echo "$json" | jshon -Q -e message -u)
 	if [ -n "$error" ]; then
 		echo $error;
@@ -147,7 +180,7 @@ function create_repo() {
 	fi
 
 	# set description
-	json=$(curl -s -u "$user:$pwd" -X PATCH -d "{\"name\":\"$name\", \"description\":\"$description\"}" https://api.github.com/repos/$org/$name)
+	json=$(curl -s $login -X PATCH -d "{\"name\":\"$name\", \"description\":\"$description\"}" https://api.github.com/repos/$org/$name)
 }
 
 	# args
@@ -156,11 +189,7 @@ function create_repo() {
 	branch=${TO[1]}
 	type=$2
 	from=$3
-	arg=$4
-
-	# title
-	echo 
-	format true -1 $to
+arg=$4
 
 	# repo home
 	if [ -z "$REPO_HOME" ]; then
@@ -176,20 +205,8 @@ if [ -z "$org" ]; then
 	org=mirror
 fi
 
-# debug
-if $isdebug; then
-	set -x
-fi
-
-# test
-if $istest; then
-	is_behind
-	# mirror_exist
-	exit
-fi
-	
 	# type
-	m="push --mirror"
+	m="push -q --mirror"
 	r='add'
 	case "$type" in
 	bzr) isbzr=true
@@ -200,7 +217,7 @@ fi
 		c="cvsimport -i -d $from $arg"
 		p="$c";;
 	git) isgit=true
-		c="clone --mirror $from ."
+		c="clone -q --mirror $from ."
 		p='remote update'
 		s=set-url
 		r='set-url --push';;
@@ -212,6 +229,11 @@ fi
 			m="push";;
 	*) echo "$type is unsupported"; return 1;;
 	esac
+	
+	# title
+	echo
+	format true -1 $to $type
+
 	
 	# branch push command
 	if [ -n "$branch" ]; then
@@ -228,8 +250,10 @@ if [[ -d $dir ]]; then
 	git $p
 
 else
+echo no existing clone on disk
+
 	if $isfast && ($issvn || $iscvs); then
-		echo --fast disable new clones for $type
+		echo --fast disable new $type clones
 		exit 1
 	fi
 
@@ -238,6 +262,31 @@ else
 		exit 1
 	fi
 
+if $isint; then
+read -s -n 1 -p "create new mirror [␣↵/*]" yn
+echo
+case $yn in
+"" ) ;;
+* ) exit;;
+esac
+fi
+
+# debug
+if $isdebug; then
+	set -x
+fi
+
+# api
+haveapi=false
+have_api haveapi
+
+# test
+if $istest; then
+	is_big
+	# is_behind
+	# mirror_exist
+	exit
+fi
 	is_big
 
 	is_behind
@@ -263,9 +312,9 @@ else
 		git remote $r origin git@github.com:$org/$to
 
 	else
-		echo clone from source
+		echo cloning $from ...
 		git $c
-		echo update remote
+		echo update remote address
 		git remote $r origin git@github.com:$org/$to
 	fi
 fi
@@ -276,20 +325,21 @@ fi
 	fi
 
 	# sync
+	echo updating $org/$to ...
 	git $m
 res=$?
 
-	# return to home
+	# return home
 	popd
 
-# keep big and slow repos 
-if [ $isfast -a $res -eq 0 ]; then
-	format false 10 fast success $to
-	rm -rf $dir
-fi
-
-if $isint; then
-	read -p "press return to continue"
+if [ $res -eq 0 ]; then
+	format true 2 success
+	# keep big and slow repos 
+	if $isfast && $isgit; then
+		rm -rf $dir
+	fi
+else
+	format true 9 fail
 fi
 
 if $isdebug; then set +x; fi

--- a/mirror.sh
+++ b/mirror.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # Repo list
 
-# import
-source git_login.sh
-# source git_mirror.sh
-
 args=$@
 
 function git_mirror() {

--- a/mirror.sh
+++ b/mirror.sh
@@ -5,12 +5,14 @@
 source git_login.sh
 # source git_mirror.sh
 
+args=$@
+
 function git_mirror() {
-	bash git_mirror.sh $@
+	bash git_mirror.sh $@ $args
 }
 
 # test
-# git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk --dry-run; exit
+# git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk; exit
 
 # repos
 git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk

--- a/mirror.sh
+++ b/mirror.sh
@@ -11,11 +11,6 @@ else
 fi
 }
 
-# test
-# git_mirror xmlrpc-c svn http://svn.code.sf.net/p/xmlrpc-c/code '--ignore-paths=^(release_number|super_stable|userguide)'
-# git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk
-# exit
-
 # repos
 git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk
 git_mirror busybox git git://busybox.net/busybox.git
@@ -76,6 +71,7 @@ git_mirror vbam svn https://svn.code.sf.net/p/vbam/code
 git_mirror vbox svn http://www.virtualbox.org/svn/vbox/trunk
 git_mirror virtualjaguar git http://shamusworld.gotdns.org/git/virtualjaguar
 git_mirror VMsvga2 svn svn://svn.code.sf.net/p/vmsvga2/code/VMsvga2/trunk
+git_mirror waver bzr lp:waver
 git_mirror wget git git://git.sv.gnu.org/wget.git
 git_mirror winscp cvs :pserver:anonymous@winscp.cvs.sourceforge.net:/cvsroot/winscp winscp3
 git_mirror x264 git http://git.videolan.org/git/x264.git

--- a/mirror.sh
+++ b/mirror.sh
@@ -2,8 +2,15 @@
 # Repo list
 
 # import
-. git_login.sh
-. git_mirror.sh
+source git_login.sh
+# source git_mirror.sh
+
+function git_mirror() {
+	bash git_mirror.sh $@
+}
+
+# test
+# git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk --dry-run; exit
 
 # repos
 git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk

--- a/mirror.sh
+++ b/mirror.sh
@@ -68,7 +68,7 @@ git_mirror soundtouch svn https://svn.code.sf.net/p/soundtouch/code/trunk
 git_mirror tclap git git://git.code.sf.net/p/tclap/code
 git_mirror tinycc git git://repo.or.cz/tinycc.git
 git_mirror vbam svn https://svn.code.sf.net/p/vbam/code
-git_mirror vbox svn http://www.virtualbox.org/svn/vbox/trunk
+git_mirror vbox svn https://www.virtualbox.org/svn/vbox/trunk
 git_mirror virtualjaguar git http://shamusworld.gotdns.org/git/virtualjaguar
 git_mirror VMsvga2 svn svn://svn.code.sf.net/p/vmsvga2/code/VMsvga2/trunk
 git_mirror waver bzr lp:waver

--- a/mirror.sh
+++ b/mirror.sh
@@ -4,11 +4,17 @@
 args=$@
 
 function git_mirror() {
+if [ $# -lt 4 ]; then
+	bash git_mirror.sh $@ "" $args
+else
 	bash git_mirror.sh $@ $args
+fi
 }
 
 # test
-# git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk; exit
+# git_mirror xmlrpc-c svn http://svn.code.sf.net/p/xmlrpc-c/code '--ignore-paths=^(release_number|super_stable|userguide)'
+# git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk
+# exit
 
 # repos
 git_mirror astyle svn https://svn.code.sf.net/p/astyle/code/trunk

--- a/mirror.sh
+++ b/mirror.sh
@@ -27,7 +27,6 @@ git_mirror cvs-fast-export git git://gitorious.org/cvs-fast-export/cvs-fast-expo
 git_mirror cvsps git git://gitorious.org/cvsps/cvsps.git
 git_mirror daphne-emu svn https://www.daphne-emu.com:9443/daphnesvn/branches/v_1_0
 git_mirror darwinbuild svn http://svn.macosforge.org/repository/darwinbuild/trunk
-git_mirror dd-wrt svn svn://svn.dd-wrt.com/DD-WRT
 git_mirror desmume svn https://svn.code.sf.net/p/desmume/code/trunk
 git_mirror dmidecode git http://git.savannah.gnu.org/r/dmidecode.git
 git_mirror env-man git git://env-man.git.sourceforge.net/gitroot/env-man/env-man
@@ -78,7 +77,6 @@ git_mirror vbox svn http://www.virtualbox.org/svn/vbox/trunk
 git_mirror virtualjaguar git http://shamusworld.gotdns.org/git/virtualjaguar
 git_mirror VMsvga2 svn svn://svn.code.sf.net/p/vmsvga2/code/VMsvga2/trunk
 git_mirror wget git git://git.sv.gnu.org/wget.git
-git_mirror wiimms-iso-tools svn http://opensvn.wiimm.de/wii/branches/public/wiimms-iso-tools
 git_mirror winscp cvs :pserver:anonymous@winscp.cvs.sourceforge.net:/cvsroot/winscp winscp3
 git_mirror x264 git http://git.videolan.org/git/x264.git
 git_mirror xmlrpc-c svn http://svn.code.sf.net/p/xmlrpc-c/code '--ignore-paths=^(release_number|super_stable|userguide)'
@@ -87,3 +85,8 @@ git_mirror xserver git git://anongit.freedesktop.org/xorg/xserver
 
 # The following projects are dead:
 # git_mirror vba-rerecording svn http://vba-rerecording.googlecode.com/svn/trunk
+
+# already at https://github.com/DD-WRT-CN/ddwrt
+# git_mirror dd-wrt svn svn://svn.dd-wrt.com/DD-WRT
+# https://github.com/Wiimm/wiimms-iso-tools
+# git_mirror wiimms-iso-tools svn http://opensvn.wiimm.de/wii/branches/public/wiimms-iso-tools


### PR DESCRIPTION
gh pr edit 47

dry run with any of these

~~~
bash git_mirror.sh sed git git://git.savannah.gnu.org/sed.git --dry-run

bash mirror.sh -n
~~~

print everything

~~~
bash mirror.sh -d
~~~

skip cvs svn unless they already exist and ask every time

~~~
bash mirror.sh --fast --interactive
~~~

only hg

~~~
bash mirror.sh --type=hg
~~~

 i will try to update all repos before I fly to Johannesburg

# mirror svn cvs

they are now mirrored and it might possible to resume the cloned mirror the next time

the reverse mirror should now download additional info that might be used to resume instead of starting over from scratch 

~~~
git clone --mirror https://github.com/mirror/astyle

.git/config
[svn-remote "svn"]
	url = https://svn.code.sf.net/p/astyle/code/trunk
	fetch = :refs/remotes/git-svn
~~~

